### PR TITLE
Removed whitespace from Game ID in host header

### DIFF
--- a/src/components/Host/Host.js
+++ b/src/components/Host/Host.js
@@ -224,7 +224,7 @@ class Host extends Component {
    * @description [copies selection to clipboard.]
    */
   copyToClipboard = (target) => {
-    let text = document.getElementById(target).innerText;
+    let text = document.getElementById(target).innerText.trim();
     navigator.clipboard.writeText(text).then(() => {
       alert("Copied!");
     });

--- a/src/components/Player/Join/Join.js
+++ b/src/components/Player/Join/Join.js
@@ -37,7 +37,3 @@ export default function Join(props) {
         </div >
     )
 }
-
-
-
-


### PR DESCRIPTION
Added .trim() on the Game ID in Host;
when copied to clipboard whitespace is gone