### PR TITLE
Leaderboard transition button cleanup

### DIFF
--- a/src/components/HOCs/withPeerJs/withPeerJs.js
+++ b/src/components/HOCs/withPeerJs/withPeerJs.js
@@ -75,7 +75,6 @@ const withPeerJs = (WrappedComponent) => {
         catchOthers = (data) => {
           if (data.individualResults) {
             this.updateResults(data);
-
           }
         }
 

--- a/src/components/Host/Host.js
+++ b/src/components/Host/Host.js
@@ -29,7 +29,6 @@ class Host extends Component {
   * @property { Number } currentQ - Index of current question.
   * @property { Number } time - How many seconds to set timer.
   * @property { String } chosenAnswer - String holding chosen answer.
-  * @property { String } message - content of message to be sent.
   *
   */
   state = {
@@ -43,11 +42,10 @@ class Host extends Component {
     questions: [],
     currentQ: 0,
     chosenAnswer: '',
-    message: '',
     readyLeaderBoard: false
   }
 
-  
+
   /* PUSH URL */
   /**
    * @function pushLocation
@@ -136,14 +134,6 @@ class Host extends Component {
     this.setState({
       [name]: value
     });
-  }
-
-  handleMessage = () => {
-
-    this.props.data.players.forEach(conn => {
-      conn.send(this.state.message);
-    });
-
   }
 
   handleUsername = (e) => {
@@ -264,11 +254,6 @@ class Host extends Component {
         </section>
 
         <br />
-        {/* TODO: REMOVE THIS WHEN GAME IS RUNNING */}
-        <input name='message' value={this.state.message} onChange={this.handleInputChange} />
-        <button onClick={this.handleMessage} >Send Message</button>
-        <br />
-        <button onClick={this.goLeaderboard} >Go LeaderBoard</button>
 
         <Switch>
 

--- a/src/components/Host/Host.js
+++ b/src/components/Host/Host.js
@@ -89,6 +89,15 @@ class Host extends Component {
 
      }, 1000)
 
+     // if there are no players connected, single player mode
+     if(this.props.data.players.length === 0){
+       //show leaderboard push button
+       this.setState({ readyLeaderBoard : true });
+       //update own score in users object
+       let username = this.state.me.userName;
+       let scoreObj = {[username]: this.state.me.myScore };
+       this.setState({ users : scoreObj });
+     }
   }
 
   handleLeaderBoardTransition = () => {
@@ -161,7 +170,6 @@ class Host extends Component {
   }
 
   goNextQuestion = () => {
-      this.unreadyLeaderBoard();
       this.props.data.players.forEach(conn => {
         conn.send("go Next Question");
       });
@@ -173,6 +181,7 @@ class Host extends Component {
         conn.send("go Leaderboard");
       });
       this.pushLocation("/host/leaderboard");
+      this.unreadyLeaderBoard();
     }
 
   /* Increment Current Q */

--- a/src/components/Host/Host.js
+++ b/src/components/Host/Host.js
@@ -33,12 +33,7 @@ class Host extends Component {
   */
   state = {
     me: null,
-    users: {
-      Inky: 50,
-      Blinky: 5,
-      Pinky: 10,
-      Clyde: 120,
-    },
+    users: {},
     questions: [],
     currentQ: 0,
     chosenAnswer: '',
@@ -83,20 +78,9 @@ class Host extends Component {
    */
   sendAnswer = (correct, answer) => {
 
-    // TODO: Handle setting own state before moving on
-
-    // Display data being sent to the host
-    console.log({
-      correct,
-      answer,
-      username: this.state.username
-    })
-
-    // At this point we should be waiting for a response from the host.
-    // TODO: Add function to gather info from players and send players object beck to players with updated results
     console.log('Waiting for signal from players');
 
-    // Mimicking response from Host
+    // Pausing while others are still answering Qs
      setTimeout(() => {
 
        // Highlighting the correct answer
@@ -111,7 +95,6 @@ class Host extends Component {
 
     this.props.data.players.forEach(conn => {
       conn.send("go Leaderboard");
-      console.log("pushing to leaderboard");
     });
 
   }
@@ -120,20 +103,8 @@ class Host extends Component {
 
     this.props.data.players.forEach(conn => {
       conn.send("start");
-      console.log("start game");
     });
 
-  }
-
-  // TODO: Remove after game is working
-  handleInputChange = ({ target }) => {
-
-    const value = target.value;
-    const name = target.name;
-
-    this.setState({
-      [name]: value
-    });
   }
 
   handleUsername = (e) => {
@@ -154,7 +125,7 @@ class Host extends Component {
         ...this.props.data.users,
         [this.state.me.userName]: this.state.me.myScore,
       },
-    }, console.log("1st ", this.state.users));
+    });
     this.setState({
       users: Object.assign({}, this.props.data.users, {
         [this.state.me.userName]: this.state.me.myScore,
@@ -162,8 +133,6 @@ class Host extends Component {
     });
     this.props.resetPlayersUpdated();
     this.setState({ readyToSend : true });
-    console.log("host updated", this.state.users);
-
   }
 
   componentDidUpdate() {
@@ -197,7 +166,6 @@ class Host extends Component {
         conn.send("go Next Question");
       });
       this.pushLocation("/host/questions");
-      console.log("push to next question");
     }
 
     goLeaderboard = () => {
@@ -205,7 +173,6 @@ class Host extends Component {
         conn.send("go Leaderboard");
       });
       this.pushLocation("/host/leaderboard");
-      console.log("push to leaderboard");
     }
 
   /* Increment Current Q */

--- a/src/components/LeaderBoard/LeaderBoard.js
+++ b/src/components/LeaderBoard/LeaderBoard.js
@@ -11,7 +11,6 @@ export default function LeaderBoard(props) {
  */
   useEffect(() => {
     props.handleIncrementQ();
-    console.log('why !!!');
   }, []);
 
   /**

--- a/src/components/Player/Player.js
+++ b/src/components/Player/Player.js
@@ -34,9 +34,7 @@ class Player extends Component {
       userName: "",
       myScore: 0
     },
-    users: {
-
-    },
+    users: {},
     questions: [],
     currentQ: 0,
     time: 10,
@@ -108,17 +106,16 @@ class Player extends Component {
     this.sendChosenAnswer(correct, answer, localScore);
 
     // At this point we should be waiting for a response from the host.
-    // TODO: Add function to gather info from players and send players object beck to players with updated results
     console.log('Waiting for signal from host');
 
-    // Mimicking response from Host
+    // Pausing while others are still answering Qs
     setTimeout(() => {
 
       // Highlighting the correct answer
       let correct = document.querySelector('.correct');
       correct.classList.add('highlight');
 
-    }, 3000)
+    }, 1000)
 
   }
 
@@ -132,16 +129,6 @@ class Player extends Component {
       this.state.conn.send(msg);
       console.log("Sent: " + msg);
     }
-  }
-
-  handleInputChange = ({ target }) => {
-
-    const value = target.value;
-    const name = target.name;
-
-    this.setState({
-      [name]: value
-    });
   }
 
   handleConnection = (id) => {
@@ -180,7 +167,6 @@ class Player extends Component {
         break;
       case "go Leaderboard":
         this.goLeaderboard();
-        console.log("do something to transition to Leaderboard");
         break;
       case "go Next Question":
         this.goNextQuestion();
@@ -209,7 +195,6 @@ class Player extends Component {
     if (data.usersObject) {
       this.updateUsersObject(data);
     }
-    console.log(this.state.users);
   }
 
   updateUsersObject = (data) => {
@@ -220,7 +205,6 @@ class Player extends Component {
 
     let obj = { userName: myName, myScore: 0 };
     this.setState({ me: obj });
-    console.log(this.state.me.userName);
   }
 
   updateMyScore = (score) => {
@@ -230,17 +214,14 @@ class Player extends Component {
 
   start = () => {
     this.pushLocation("/player/questions");
-    console.log("push to questions");
   }
 
   goLeaderboard = () => {
     this.pushLocation("/player/leaderboard");
-    console.log("push to leaderboard");
   }
 
   goNextQuestion = () => {
     this.pushLocation("/player/questions");
-    console.log("push to next question");
   }
 
   render() {

--- a/src/components/Player/Player.js
+++ b/src/components/Player/Player.js
@@ -27,7 +27,6 @@ class Player extends Component {
   * @property { Number } currentQ - Index of current question.
   * @property { Number } time - How many seconds to set timer.
   * @property { String } chosenAnswer - String holding chosen answer.
-  * @property { String } message - content of message to be sent.
   *
   */
   state = {
@@ -41,7 +40,6 @@ class Player extends Component {
     questions: [],
     currentQ: 0,
     time: 10,
-    message: '',
     isConnected: false,
     input: '',
     conn: '',
@@ -50,8 +48,8 @@ class Player extends Component {
   componentDidMount() {
     this.loadQuestions();
   }
-  
-  loadQuestions() { 
+
+  loadQuestions() {
     return fetch('/api/questions')
       .then(res => {
         if (!res.ok) {
@@ -59,7 +57,7 @@ class Player extends Component {
         }
         return res.json();
         })
-        .then(data => 
+        .then(data =>
           this.setState({
             questions: data[0].questions,
           })
@@ -146,11 +144,6 @@ class Player extends Component {
     });
   }
 
-  handleMessage = () => {
-
-    this.state.conn.send(this.state.message)
-
-  }
   handleConnection = (id) => {
     let conn = this.props.data.peer.connect(id, {
       reliable: true


### PR DESCRIPTION
I realized that the button to transition to leaderboard and thus be able to get to the next question will not show up if there is only the host playing. If the host (or one of us) wanted to test out the questions or anything, we would be stuck at the first question with no way to transition. So, I added a single player mode to the sendAnswer method in the Host component.